### PR TITLE
Multiple Farm Management Improvements

### DIFF
--- a/src/dapp/App.tsx
+++ b/src/dapp/App.tsx
@@ -26,6 +26,10 @@ export const App: React.FC = () => {
         console.log('Network changed')
         send('NETWORK_CHANGED')
       });
+
+      window.ethereum.on('accountsChanged', function (accounts) {
+        send('ACCOUNT_CHANGED')
+      })
     }
   }, [send])
   

--- a/src/dapp/Blockchain.ts
+++ b/src/dapp/Blockchain.ts
@@ -8,6 +8,7 @@ import { Transaction, Square, Charity, Fruit  } from './types/contract'
 interface Account {
     farm: Square[]
     balance: number
+    id: string
 }
 
 export class BlockChain {
@@ -21,23 +22,7 @@ export class BlockChain {
 
     private isTrialAccount: boolean = false
 
-    private async connectToGanache() {
-        // const netId = await this.web3.eth.net.getId();
-        // console.log({ netId })
-        // const accounts = await this.web3.eth.requestAccounts()
-        // this.account = accounts[0]
-
-        // console.log({ netId })
-        // this.token = new this.web3.eth.Contract(Token.abi as any, Token.networks[netId].address)
-
-        // const farmAddress = Farm.networks[netId].address
-        // this.farm = new this.web3.eth.Contract(Farm.abi as any, farmAddress)
-    }
-
     private async connectToMumbai(){
-
-        // web3.eth.defaultAddress = '0xd94A0D37b54f540F6FB93c5bEcbf89b84518D621'
-        // web3.eth.handleRevert = true
 
         this.token = new this.web3.eth.Contract(Token as any, '0x8B0e84C5D75C9b489119bde5fA9136212C7e86A8')
         this.farm = new this.web3.eth.Contract(Farm as any, '0x84a23593ba916aDACA311A19a0648e6f8cc90612')
@@ -47,10 +32,6 @@ export class BlockChain {
     }
 
     private async connectToMatic(){
-
-        // web3.eth.defaultAddress = '0xd94A0D37b54f540F6FB93c5bEcbf89b84518D621'
-        // web3.eth.handleRevert = true
-
         try {
             this.token = new this.web3.eth.Contract(Token as any, '0x3b4F867D50231a9263cDAEd87C80C3962b1483D7')
             this.farm = new this.web3.eth.Contract(Farm as any, '0xBc00E1aFBB8FC859a79E54902FDe8fa0B26412d6')
@@ -68,22 +49,6 @@ export class BlockChain {
             }
         }
 
-    }
-
-    private async connectToHarmony(){
-        // this.token = new this.web3.eth.Contract(Token.abi as any, '0xCFc5b0e65f9a684C0180037eef201EF025D37971')
-        // this.farm = new this.web3.eth.Contract(Farm.abi as any, '0x1ecE946c332C9AffC28b82D73B720Ac9D984f5fF')
-
-        // const maticAccounts = await this.web3.eth.getAccounts()
-        // this.account = maticAccounts[0]
-    }
-
-    private async connectToBinance(){
-        // this.token = new this.web3.eth.Contract(Token.abi as any, '0xCFc5b0e65f9a684C0180037eef201EF025D37971')
-        // this.farm = new this.web3.eth.Contract(Farm.abi as any, '0x1ecE946c332C9AffC28b82D73B720Ac9D984f5fF')
-
-        // const maticAccounts = await this.web3.eth.getAccounts()
-        // this.account = maticAccounts[0]
     }
 
 
@@ -118,7 +83,6 @@ export class BlockChain {
             // It is actually quite fast, we won't to simulate slow loading to convey complexity
             await new Promise(res => window.setTimeout(res, 1000))
             await this.setupWeb3()
-            const chain = await this.web3.eth.net.getNetworkType()
             const chainId = await this.web3.eth.getChainId()
 
             if (chainId === 137) {
@@ -129,15 +93,7 @@ export class BlockChain {
                 await this.connectToMumbai()
 
                 this.details = await this.getAccount()
-            } else if (chainId === 1666700000) {
-                await this.connectToHarmony()
-
-                this.details = await this.getAccount()
-            } else if (chainId === 97) {
-                await this.connectToBinance()
-
-                this.details = await this.getAccount()
-            }else {
+            } else {
                 throw new Error('WRONG_CHAIN')
             }
 
@@ -260,6 +216,7 @@ export class BlockChain {
                     fruit: Fruit.None
                 }],
                 balance: 0,
+                id: this.account,
             }
         }
 
@@ -270,6 +227,7 @@ export class BlockChain {
         return {
             balance: Number(balance),
             farm,
+            id: this.account,
         }
 
     }
@@ -352,5 +310,9 @@ export class BlockChain {
             ...event,
             createdAt: event.createdAt + difference,
         }))
+    }
+
+    public resetFarm() {
+        this.events = []
     }
 }

--- a/src/dapp/components/farm/Farm.tsx
+++ b/src/dapp/components/farm/Farm.tsx
@@ -76,7 +76,6 @@ export const Farm: React.FC = () => {
 
             // HACK: Upgrade modal does not upgrade balance and farm so mark farm as stale
             if (machineState.matches('upgrading') || machineState.matches('loading')) {
-                console.log('Refresh')
                 farmIsFresh.current = false
             }
 

--- a/src/dapp/components/farm/Farm.tsx
+++ b/src/dapp/components/farm/Farm.tsx
@@ -6,6 +6,7 @@ import { Land } from './Land'
 
 import { FruitItem, FRUITS, getMarketFruits } from '../../types/fruits'
 import { Fruit, Square, Action, Transaction } from '../../types/contract'
+import { cacheAccountFarm, getFarm } from '../../utils/localStorage'
 
 import {
     service,
@@ -34,6 +35,7 @@ export const Farm: React.FC = () => {
         })
     )
     const farmIsFresh = React.useRef(false)
+    const accountId = React.useRef<string>()
     const [fruit, setFruit] = React.useState<Fruit>(
         (localStorage.getItem('fruit') as Fruit) || Fruit.Sunflower
     )
@@ -73,7 +75,8 @@ export const Farm: React.FC = () => {
             const doRefresh = !farmIsFresh.current
 
             // HACK: Upgrade modal does not upgrade balance and farm so mark farm as stale
-            if (machineState.matches('upgrading')) {
+            if (machineState.matches('upgrading') || machineState.matches('loading')) {
+                console.log('Refresh')
                 farmIsFresh.current = false
             }
 
@@ -86,10 +89,16 @@ export const Farm: React.FC = () => {
                 const {
                     farm,
                     balance: currentBalance,
+                    id,
                 } = await machineState.context.blockChain.getAccount()
+                console.log('Load latest')
                 setLand(farm)
                 setBalance(new Decimal(currentBalance))
                 farmIsFresh.current = true
+                accountId.current = id
+
+                const cachedFarm = getFarm(id)
+                setFruit(cachedFarm.selectedFruit)
 
                 const supply = await machineState.context.blockChain.totalSupply()
                 const marketRate = getMarketRate(supply)
@@ -104,6 +113,7 @@ export const Farm: React.FC = () => {
     const onChangeFruit = (fruit: Fruit) => {
         setFruit(fruit)
 
+        cacheAccountFarm(accountId.current, { selectedFruit: fruit })
         localStorage.setItem('fruit', fruit)
     }
     const onHarvest = React.useCallback(

--- a/src/dapp/components/modals/Connecting.tsx
+++ b/src/dapp/components/modals/Connecting.tsx
@@ -5,7 +5,7 @@ export const Connecting: React.FC = () => (
     <Panel>
         <div id="welcome">
             <h1 className="header">
-            Connecting to metamask...
+            Loading...
             </h1>
         </div>
     </Panel>

--- a/src/dapp/machine.ts
+++ b/src/dapp/machine.ts
@@ -87,6 +87,9 @@ export type BlockchainEvent =
     | FinishEvent
     | CloseOnboardingEvent
     | OnboardingEvent
+    | {
+        type: 'ACCOUNT_CHANGED'
+    }
 
 
 export type OnboardingStates = 'harvesting' | 'token' | 'planting' | 'saving' | 'market'
@@ -222,6 +225,10 @@ export const blockChainMachine = createMachine<
                 },
                 TIMER_COMPLETE: {
                     target: 'timerComplete'
+                },
+                ACCOUNT_CHANGED: {
+                    target: 'loading',
+                    actions: (context) => context.blockChain.resetFarm()
                 }
             }
         },

--- a/src/dapp/utils/localStorage.ts
+++ b/src/dapp/utils/localStorage.ts
@@ -20,17 +20,18 @@ function getFarms(): CachedFarms {
         return {}
     }
 
-    return JSON.parse(stored)
+    try {
+        const parsed = JSON.parse(stored)
+
+        return parsed
+    } catch (e) {
+        console.error("Parsing localstorage failed: ", e)
+        return {}
+    }
 }
 
 export function getFarm(accountId: string): FarmState {
-    const stored = localStorage.getItem(CACHED_FARMS_KEY)
-
-    if (!stored) {
-        return DEFAULT
-    }
-
-    const farms: CachedFarms = JSON.parse(stored)
+    const farms = getFarms()
     const farm = farms[accountId]
 
     if (!farm) {

--- a/src/dapp/utils/localStorage.ts
+++ b/src/dapp/utils/localStorage.ts
@@ -1,0 +1,51 @@
+import { Fruit } from "../types/contract";
+
+interface FarmState {
+    selectedFruit: Fruit
+}
+
+// Account ID -> FarmState
+type CachedFarms = Record<string, FarmState>
+
+const CACHED_FARMS_KEY = 'farms'
+
+const DEFAULT: FarmState = {
+    selectedFruit: Fruit.Sunflower
+}
+
+function getFarms(): CachedFarms {
+    const stored = localStorage.getItem(CACHED_FARMS_KEY)
+
+    if (!stored) {
+        return {}
+    }
+
+    return JSON.parse(stored)
+}
+
+export function getFarm(accountId: string): FarmState {
+    const stored = localStorage.getItem(CACHED_FARMS_KEY)
+
+    if (!stored) {
+        return DEFAULT
+    }
+
+    const farms: CachedFarms = JSON.parse(stored)
+    const farm = farms[accountId]
+
+    if (!farm) {
+        return DEFAULT
+    }
+
+    return farm
+}
+
+export function cacheAccountFarm(accountId: string, state: FarmState) {
+    const farms = getFarms()
+    const newFarms: CachedFarms = {
+        ...farms,
+        [accountId]: state,
+    }
+
+    localStorage.setItem(CACHED_FARMS_KEY, JSON.stringify(newFarms))
+}


### PR DESCRIPTION
This PR includes 2 improvements to help users manage multiple farms.

1. Switching Metamask accounts will refresh the farm
2. If you change accounts it will remember the fruit you had selected for the that account.

_Note - Switching only gets fired from the `farming` state. To avoid side effects we do not enable switching while they are saving or upgrading a farm_

**Local Storage Structure**

Introduces a new structure so we can store different types of metadata against different accounts.

This works by using the Account ID as the key and an object as the value pair. This is stored under `farms`

![Screen Shot 2021-10-03 at 9 56 51 am](https://user-images.githubusercontent.com/11745561/135733784-d7785360-10f2-4296-ab78-8196541a9266.png)

### How to test?

Start farming and swapping fruits for different accounts
